### PR TITLE
Linux build and IPv4 validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ if (MSVC)
     add_definitions(-DUNICODE)
     add_definitions(-D_UNICODE)
     set(SOCKET_LIB wsock32 ws2_32)
+elseif(UNIX)
+    # Compilation under Linux (Basically MinGW config + pthread flag, -static stdc(++) linkage (causes QApplication crash)
+    # fill the build definitions for Linux build subsystem in here
+    set(CMAKE_CXX_FLAGS " -std=c++14 -fpermissive -Wall -pthread")
+    set(CMAKE_CXX_FLAGS_RELEASE " -O3 -s -Wclobbered -Wignored-qualifiers -Wuninitialized -Wold-style-cast -Wreorder -Wno-unused-parameter -Wno-unknown-pragmas -Wno-unused-function -fno-rtti -fno-jump-tables -ffunction-sections -fdata-sections -fstack-protector-strong -Wl,--gc-sections -Wl,--strip-all")
+    set(CMAKE_CXX_FLAGS_DEBUG " -g -Wold-style-cast -DCOMPILE_WITH_LOGS")
+    add_definitions(-DUNICODE)
+    add_definitions(-D_UNICODE)
 else()
     # MINGW
     # fill the build definitions for the MinGW build subsystem in here

--- a/src/dialogaddserver.cpp
+++ b/src/dialogaddserver.cpp
@@ -11,10 +11,10 @@ QRegExp DialogAddServer::ipV4Regex = QRegExp("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-
 DialogAddServer::DialogAddServer(QWidget *parent) :
     QDialog(parent),
     m_pUi(new Ui::DialogAddServer),
-    m_pIPv4Validator(ipV4Regex, this)
+    m_IPv4Validator(ipV4Regex, this)
 {
     m_pUi->setupUi(this);
-    m_pUi->editUrl->setValidator(&m_pIPv4Validator);
+    m_pUi->editUrl->setValidator(&m_IPv4Validator);
 
     connect(m_pUi->buttonAddServer, &QPushButton::clicked, [this]()
     {

--- a/src/dialogaddserver.cpp
+++ b/src/dialogaddserver.cpp
@@ -6,15 +6,17 @@
 #include "dialogaddserver.h"
 #include "ui_dialogaddserver.h"
 
-QRegExp DialogAddServer::ipV4Regex = QRegExp("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+QRegExp DialogAddServer::ipV4Regex          = QRegExp("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+QRegExp DialogAddServer::ipV6Regex          = QRegExp("^([0-9a-f]){1,4}(:([0-9a-f]){1,4}){7}$");
+QRegExp DialogAddServer::ipHostnameRegex    = QRegExp("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
 
 DialogAddServer::DialogAddServer(QWidget *parent) :
     QDialog(parent),
     m_pUi(new Ui::DialogAddServer),
-    m_IPv4Validator(ipV4Regex, this)
+    m_IPValidator(ipV4Regex, this)
 {
     m_pUi->setupUi(this);
-    m_pUi->editUrl->setValidator(&m_IPv4Validator);
+    m_pUi->editUrl->setValidator(&m_IPValidator);
 
     connect(m_pUi->buttonAddServer, &QPushButton::clicked, [this]()
     {
@@ -31,4 +33,34 @@ DialogAddServer::DialogAddServer(QWidget *parent) :
 DialogAddServer::~DialogAddServer()
 {
     delete m_pUi;
+}
+
+void DialogAddServer::checkRegexAndClearIfInvalid(QRegExp &regex)
+{
+    if(!regex.exactMatch(m_pUi->editUrl->text()))
+        m_pUi->editUrl->clear();
+}
+
+void DialogAddServer::on_rbt_IPv4_clicked()
+{
+    m_pUi->rbt_IPv6->setChecked(false);
+    m_pUi->rbt_IPHostname->setChecked(false);
+    m_IPValidator.setRegExp(ipV4Regex);
+    checkRegexAndClearIfInvalid(ipV4Regex);
+}
+
+void DialogAddServer::on_rbt_IPv6_clicked()
+{
+    m_pUi->rbt_IPv4->setChecked(false);
+    m_pUi->rbt_IPHostname->setChecked(false);
+    m_IPValidator.setRegExp(ipV6Regex);
+    checkRegexAndClearIfInvalid(ipV6Regex);
+}
+
+void DialogAddServer::on_rbt_IPHostname_clicked()
+{
+    m_pUi->rbt_IPv4->setChecked(false);
+    m_pUi->rbt_IPv6->setChecked(false);
+    m_IPValidator.setRegExp(ipHostnameRegex);
+    checkRegexAndClearIfInvalid(ipHostnameRegex);
 }

--- a/src/dialogaddserver.cpp
+++ b/src/dialogaddserver.cpp
@@ -1,15 +1,20 @@
 #include <QPushButton>
 #include <QLineEdit>
 #include <QSpinBox>
+#include <QRegExp>
 
 #include "dialogaddserver.h"
 #include "ui_dialogaddserver.h"
 
+QRegExp DialogAddServer::ipV4Regex = QRegExp("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+
 DialogAddServer::DialogAddServer(QWidget *parent) :
     QDialog(parent),
-    m_pUi(new Ui::DialogAddServer)
+    m_pUi(new Ui::DialogAddServer),
+    m_pIPv4Validator(ipV4Regex, this)
 {
     m_pUi->setupUi(this);
+    m_pUi->editUrl->setValidator(&m_pIPv4Validator);
 
     connect(m_pUi->buttonAddServer, &QPushButton::clicked, [this]()
     {

--- a/src/dialogaddserver.h
+++ b/src/dialogaddserver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QRegExpValidator>
 
 namespace Ui {
     class DialogAddServer;
@@ -16,6 +17,8 @@ public:
 
 private:
     Ui::DialogAddServer *m_pUi;
+    QRegExpValidator m_pIPv4Validator;
+    static QRegExp ipV4Regex;
 
 signals:
     void selected(const QString &name, const QString &url, quint16 port);

--- a/src/dialogaddserver.h
+++ b/src/dialogaddserver.h
@@ -17,9 +17,17 @@ public:
 
 private:
     Ui::DialogAddServer *m_pUi;
-    QRegExpValidator m_IPv4Validator;
+    QRegExpValidator m_IPValidator;
     static QRegExp ipV4Regex;
+    static QRegExp ipV6Regex;
+    static QRegExp ipHostnameRegex;
+    void checkRegexAndClearIfInvalid(QRegExp &validator);
 
 signals:
     void selected(const QString &name, const QString &url, quint16 port);
+
+private slots:
+    void on_rbt_IPv4_clicked();
+    void on_rbt_IPv6_clicked();
+    void on_rbt_IPHostname_clicked();
 };

--- a/src/dialogaddserver.h
+++ b/src/dialogaddserver.h
@@ -17,7 +17,7 @@ public:
 
 private:
     Ui::DialogAddServer *m_pUi;
-    QRegExpValidator m_pIPv4Validator;
+    QRegExpValidator m_IPv4Validator;
     static QRegExp ipV4Regex;
 
 signals:

--- a/src/dialogaddserver.ui
+++ b/src/dialogaddserver.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>160</height>
+    <height>202</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,14 +16,14 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Url</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QLineEdit" name="editUrl">
        <property name="inputMethodHints">
         <set>Qt::ImhUrlCharactersOnly</set>
@@ -44,18 +44,64 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Port</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QSpinBox" name="editPort">
        <property name="maximum">
         <number>65535</number>
        </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>UrlType</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QRadioButton" name="rbt_IPv4">
+          <property name="text">
+           <string>IPv4</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rbt_IPv6">
+          <property name="text">
+           <string>IPv6</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rbt_IPHostname">
+          <property name="text">
+           <string>Hostname</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
This Pull request contains the following changes:

1. To compile the program, I needed to add the -pthread flag to CXX Flags (otherwise undefined reference to pthread_mutexattr_init)

2. Static linkage of stdc and stdc++ causes the QApplication constructor to crash (on my XUbuntu 17.10 system).

3. Regarding to Issue #1 I added a regular expression IPv4 validator to the url field.
- `+` No invalid input can be entered anymore.
- `+` The user is protected from inserting bad characters, while he is typing.
- `-` ~~No ipv6 or hostname insertion possible~~.
- `+` All types of addresses now possible and validated.